### PR TITLE
Título menos ambíguo

### DIFF
--- a/amz1_wfi_l4_sr.json
+++ b/amz1_wfi_l4_sr.json
@@ -1,8 +1,8 @@
 {
     "id": 24,
     "name": "AMZ1-WFI-L4-SR",
-    "title": "AMAZONIA-1/WFI - Level 4 - Cloud Optimized GeoTIFF",
-    "description": "AMAZONIA-1/WFI Surface Reflectance product over Brazil. L4 product provides orthorectified surface reflectance images. This dataset is provided as Cloud Optimized GeoTIFF (COG).",
+    "title": "AMAZONIA-1/WFI - Level 4 SR - Cloud Optimized GeoTIFF",
+    "description": "AMAZONIA-1/WFI Surface Reflectance product over Brazil. L4 SR product provides orthorectified surface reflectance images. This dataset is provided as Cloud Optimized GeoTIFF (COG).",
     "temporal_composition_schema": null,
     "composition_function": null,
     "grid_ref_sys": "AMAZONIA1_WFI_GRID",
@@ -19,7 +19,7 @@
                 ],
                 "url": "https://data.inpe.br/big/",
                 "processing:lineage": "Generation of L4 in Cloud Optimized GeoTIFF",
-                "processing:level": "L4",
+                "processing:level": "L4 SR",
                 "processing:facility": "LGI",
                 "processing:software": {
                     "bdc-collection-builder": "1.0",

--- a/cb4_mux_l4_sr.json
+++ b/cb4_mux_l4_sr.json
@@ -1,8 +1,8 @@
 {
     "id": 25,
     "name": "CB4-MUX-L4-SR",
-    "title": "CBERS-4/MUX - Level 4 - Cloud Optimized GeoTIFF",
-    "description": "CBERS-4/MUX Surface Reflectance product over Brazil. L4 product provides orthorectified surface reflectance images. This dataset is provided as Cloud Optimized GeoTIFF (COG).",
+    "title": "CBERS-4/MUX - Level 4 SR - Cloud Optimized GeoTIFF",
+    "description": "CBERS-4/MUX Surface Reflectance product over Brazil. L4 SR product provides orthorectified surface reflectance images. This dataset is provided as Cloud Optimized GeoTIFF (COG).",
     "temporal_composition_schema": null,
     "composition_function": null,
     "grid_ref_sys": "CBERS4_MUX_GRID",
@@ -19,7 +19,7 @@
                 ],
                 "url": "https://data.inpe.br/big/",
                 "processing:lineage": "Generation of L4 in Cloud Optimized GeoTIFF",
-                "processing:level": "L4",
+                "processing:level": "L4 SR",
                 "processing:facility": "LGI",
                 "processing:software": {
                     "bdc-collection-builder": "1.0",

--- a/cb4_wfi_l4_sr.json
+++ b/cb4_wfi_l4_sr.json
@@ -1,7 +1,7 @@
 {
     "name": "CB4-WFI-L4-SR",
-    "title": "CBERS-4/WFI - Level 4 - Cloud Optimized GeoTIFF",
-    "description": "CBERS-4/WFI Surface Reflectance product over Brazil. L4 product provides orthorectified surface reflectance images. This dataset is provided as Cloud Optimized GeoTIFF (COG).",
+    "title": "CBERS-4/WFI - Level 4 SR - Cloud Optimized GeoTIFF",
+    "description": "CBERS-4/WFI Surface Reflectance product over Brazil. L4 SR product provides orthorectified surface reflectance images. This dataset is provided as Cloud Optimized GeoTIFF (COG).",
     "temporal_composition_schema": null,
     "composition_function": null,
     "grid_ref_sys": null,
@@ -18,7 +18,7 @@
                 ],
                 "url": "https://data.inpe.br/big/",
                 "processing:lineage": "Generation of L4 in Cloud Optimized GeoTIFF",
-                "processing:level": "L4",
+                "processing:level": "L4 SR",
                 "processing:facility": "LGI",
                 "processing:software": {
                     "bdc-collection-builder": "1.0",

--- a/cb4a_wfi_l4_sr.json
+++ b/cb4a_wfi_l4_sr.json
@@ -1,7 +1,7 @@
 {
     "name": "CB4A-WFI-L4-SR",
-    "title": "CBERS-4A/WFI - Level 4 - Cloud Optimized GeoTIFF",
-    "description": "CBERS-4A/WFI Surface Reflectance product over Brazil. L4 product provides orthorectified surface reflectance images. This dataset is provided as Cloud Optimized GeoTIFF (COG).",
+    "title": "CBERS-4A/WFI - Level 4 SR - Cloud Optimized GeoTIFF",
+    "description": "CBERS-4A/WFI Surface Reflectance product over Brazil. L4 SR product provides orthorectified surface reflectance images. This dataset is provided as Cloud Optimized GeoTIFF (COG).",
     "temporal_composition_schema": null,
     "composition_function": null,
     "grid_ref_sys": null,
@@ -18,7 +18,7 @@
                 ],
                 "url": "https://data.inpe.br/big/",
                 "processing:lineage": "Generation of L4 in Cloud Optimized GeoTIFF",
-                "processing:level": "L4",
+                "processing:level": "L4 SR",
                 "processing:facility": "LGI",
                 "processing:software": {
                     "bdc-collection-builder": "1.0",

--- a/cbers4-mux-2m.json
+++ b/cbers4-mux-2m.json
@@ -1,7 +1,7 @@
 {
     "id": null,
     "name": "CBERS4-MUX-2M",
-    "title": "Data Cube CBERS 4 - Level-4 - LCF 2 months",
+    "title": "Data Cube CBERS 4 - Level 4 SR- LCF 2 months",
     "description": "Earth Observation Data Cube generated from CBERS-4/MUX Level-4 SR product over Brazil extension. This dataset is provided in Cloud Optimized GeoTIFF (COG) file format. The dataset is processed with 20 meters of spatial resolution, reprojected and cropped to BDC_MD grid Version 2 (BDC_MD V2), considering a temporal compositing function of 2 months using the Least Cloud Cover First (LCF) best pixel approach.",
     "temporal_composition_schema": {
         "cycle": {
@@ -26,7 +26,7 @@
                 ],
                 "url": "https://data.inpe.br/big/",
                 "processing:lineage": "Generation of Earth Observation Data Cubes based on CBERS4-MUX in Cloud Optimized GeoTIFF",
-                "processing:level": "L4",
+                "processing:level": "L4 SR",
                 "processing:facility": "BDC/BIG",
                 "processing:software": {
                     "bdc-cube-builder": "1.0"


### PR DESCRIPTION
Deixando o título mais específico. O nível L4 **apenas** não é considerado reflectância de superfície pelo LGI.
Mais a frente, quando entrarem coleções L4 Digital Number pode haver ambiguidade.